### PR TITLE
Added CQL to ELM translation to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 *.cql
+*-elm.json

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "elmServiceURL": "http://example.com/cql/translator"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1237,8 +1237,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1257,6 +1256,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-jest": {
       "version": "26.0.1",
@@ -1702,7 +1709,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1755,6 +1761,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cql-translation-service-client": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cql-translation-service-client/-/cql-translation-service-client-0.5.0.tgz",
+      "integrity": "sha512-BGbSm/Kax7BsU0rj1zZW9R6/skH4MOp36s46QweRgKUNzOez7KWndKhRxipjC6TSHTQn0/+1G9OLMZkaLC8BIw==",
+      "requires": {
+        "axios": "^0.19.2",
+        "form-data": "3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1930,8 +1957,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -2714,6 +2740,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -5140,14 +5189,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "commander": "^5.1.0",
+    "cql-translation-service-client": "^0.5.0",
     "fhir": "^4.7.8",
     "fhirpath": "^2.1.5",
     "lodash": "^4.17.15",

--- a/src/builders/libraryBuilder.js
+++ b/src/builders/libraryBuilder.js
@@ -61,13 +61,16 @@ function generateCQL(library) {
   // Initialize cql with name and version of IG for the library
   let cql = `library ${name} version '${version}'\n\nusing FHIR version '${fhirVersion}'\n\n`;
 
+  // Add any codesystems used in the IG before anything else
+  Object.entries(CODE_SYSTEMS).forEach(([url, systemName]) => {
+    cql += `codesystem "${systemName}": '${url}'\n`;
+  });
+
+  cql += '\n';
+
   // Add valuesets based on map
   Object.entries(valueSetMap).forEach(([vsId, vsName]) => {
     cql += `valueset "${vsName}": '${vsId}'\n`;
-  });
-
-  Object.entries(CODE_SYSTEMS).forEach(([url, systemName]) => {
-    cql += `\ncodesystem "${systemName}": '${url}'\n`;
   });
 
   // Define all codes
@@ -91,7 +94,8 @@ exports.buildLibrary = (igDir, igJson) => {
   const library = {
     name: igJson.name,
     version: igJson.version,
-    fhirVersion: igJson.fhirVersion[0],
+    // fhirVersion: igJson.fhirVersion[0],
+    fhirVersion: '4.0.0', // FIXME: Hardcoding FHIR version to pass CQL-to-ELM. Replace when new image of the service supports FHIR 4.0.1
     valueSetMap: collectValueSets(igJson),
   };
 

--- a/src/helpers/cql-to-elm.js
+++ b/src/helpers/cql-to-elm.js
@@ -1,0 +1,14 @@
+const { Client } = require('cql-translation-service-client');
+const config = require('../../config.json');
+
+exports.convertBasicCQL = async (cql) => {
+  const cqlTranslationClient = new Client(config.elmServiceURL);
+  const elm = await cqlTranslationClient.convertBasicCQL(cql);
+  const errorMessages = (elm.library && elm.library.annotation).filter((m) => m.errorSeverity === 'error');
+
+  if (errorMessages.length > 0) {
+    throw new Error(JSON.stringify(errorMessages));
+  }
+
+  return elm;
+};


### PR DESCRIPTION
* Adds ability to configure a url for the [cql-translation-service](https://github.com/cqframework/cql-translation-service)
* After CQL is generated, run translation and catch any errors
* Service doesn't support fhir 4.0.1 yet. Hardcoding the generated CQL library to use fhir 4.0.0 for now so it passes translation.
* Also fixed an error in the generated CQL where codesystems needed to appear before valuesets