### PR TITLE
Oshrq 18 refactor common functionality of handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ahryman40k/ts-fhir-types": {
-      "version": "4.0.25",
-      "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.25.tgz",
-      "integrity": "sha512-CceI1T/opTk728IXQ7oJlzOvQXUtBzqwyGnCpe3vyBErV6s73wMR9ZjKUPEfMTPpUxH9yuDEgZv4gBXGX1Uz9Q==",
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@ahryman40k/ts-fhir-types/-/ts-fhir-types-4.0.32.tgz",
+      "integrity": "sha512-BDXzMJ7xb0umn0P0GpmpR+XdAq7Ws32C5lvIFDuYtgUp2SklrUiDPanx9ed8CrciFOB/cVMfMIp/hXMrDkF3Yg==",
       "dev": true,
       "requires": {
         "io-ts": "<2.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@ahryman40k/ts-fhir-types": "^4.0.25",
+    "@ahryman40k/ts-fhir-types": "^4.0.32",
     "@types/jest": "^26.0.0",
     "@types/js-base64": "^2.3.1",
     "@types/lodash": "^4.14.155",

--- a/src/__tests__/helpers/resourceHandlers.test.ts
+++ b/src/__tests__/helpers/resourceHandlers.test.ts
@@ -1,5 +1,5 @@
 import { R4 } from '@ahryman40k/ts-fhir-types';
-import { createHandler } from '../../helpers/resourceHandlers';
+import { handlerLookup } from '../../helpers/resourceHandlers';
 import exampleObservation from '../mock-ig/site/StructureDefinition-example-observation.json';
 import exampleCondition from '../mock-ig/site/StructureDefinition-example-condition.json';
 import { CQLResource } from '../../types/library-types';
@@ -77,7 +77,8 @@ const EXPECTED_CONDITION_DEFINITIONS: CQLResource = {
 };
 
 test('test handler for Observation', () => {
-  const handler = createHandler(<R4.IStructureDefinition>exampleObservation, MOCK_VALUESET_MAP);
+  const resourceHandlerClass = handlerLookup['Observation'];
+  const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleObservation, MOCK_VALUESET_MAP);
   expect(handler).toBeDefined();
 
   const result = handler!.process();
@@ -85,7 +86,9 @@ test('test handler for Observation', () => {
 });
 
 test('test handler for Condition', () => {
-  const handler = createHandler(<R4.IStructureDefinition>exampleCondition, MOCK_VALUESET_MAP);
+  const resourceHandlerClass = handlerLookup['Condition'];
+  const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleCondition, MOCK_VALUESET_MAP);
+
   expect(handler).toBeDefined();
 
   const result = handler!.process();

--- a/src/builders/libraryBuilder.ts
+++ b/src/builders/libraryBuilder.ts
@@ -91,11 +91,8 @@ export class LibraryBuilder {
 
       if (structureDef.type in handlerLookup) {
         const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
-        const resourceHandler: Handler | null  = new resourceHandlerClass(structureDef, this.valueSets);
-
-        if (resourceHandler !== null) {
-          resources.push(resourceHandler.process());
-        }
+        const resourceHandler: Handler = new resourceHandlerClass(structureDef, this.valueSets);
+        resources.push(resourceHandler.process());
       }
       else {
         logger.warn(`No handling implemented for ${structureDef.type}. Skipping ${structureDef.name}`);

--- a/src/builders/libraryBuilder.ts
+++ b/src/builders/libraryBuilder.ts
@@ -89,11 +89,8 @@ export class LibraryBuilder {
 
       logger.debug(`generating CQL definitions for profile ${structureDef.name}`);
 
-      //This is hardcoded for the resource types that we can handle now.
-      //We should expand upon this or find a better error handling method soon.
-      if (structureDef.type == 'Condition' || structureDef.type == 'Observation') {
+      if (structureDef.type in handlerLookup) {
         const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
-
         const resourceHandler: Handler | null  = new resourceHandlerClass(structureDef, this.valueSets);
 
         if (resourceHandler !== null) {
@@ -103,7 +100,6 @@ export class LibraryBuilder {
       else {
         logger.warn(`No handling implemented for ${structureDef.type}. Skipping ${structureDef.name}`);
       }
-
     });
     return resources;
   }

--- a/src/builders/libraryBuilder.ts
+++ b/src/builders/libraryBuilder.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import _ from 'lodash';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { ValueSetObject, ImplementationGuide, CQLResource, Library } from '../types/library-types';
-import { Handler, createHandler } from '../helpers/resourceHandlers';
 import { QuestionnaireBuilder } from './questionnaireBuilder';
+import { Handler, handlerLookup } from '../helpers/resourceHandlers';
 import { logger } from '../helpers/logger';
 
 const CODE_SYSTEMS: { [key: string]: string } = {
@@ -89,7 +89,17 @@ export class LibraryBuilder {
 
       logger.debug(`generating CQL definitions for profile ${structureDef.name}`);
 
-      const resourceHandler: Handler | null = createHandler(structureDef, this.valueSets);
+      //const resourceHandler: Handler | null = createHandler(structureDef, this.valueSets);
+
+      
+      const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
+
+      const resourceHandler  = new resourceHandlerClass(structureDef, this.valueSets);
+
+
+
+
+
       if (resourceHandler !== null) {
         resources.push(resourceHandler.process());
       }

--- a/src/builders/libraryBuilder.ts
+++ b/src/builders/libraryBuilder.ts
@@ -91,18 +91,21 @@ export class LibraryBuilder {
 
       //const resourceHandler: Handler | null = createHandler(structureDef, this.valueSets);
 
-      
-      const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
+      //This is hardcoded for the resource types that we can handle now.
+      //We should expand upon this or find a better error handling method soon.
+      if (structureDef.type == ('Condition' || 'Observation') ) {
+        const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
 
-      const resourceHandler  = new resourceHandlerClass(structureDef, this.valueSets);
+        const resourceHandler: Handler | null  = new resourceHandlerClass(structureDef, this.valueSets);
 
-
-
-
-
-      if (resourceHandler !== null) {
-        resources.push(resourceHandler.process());
+        if (resourceHandler !== null) {
+          resources.push(resourceHandler.process());
+        }
       }
+      else {
+        logger.warn(`No handling implemented for ${structureDef.type}. Skipping ${structureDef.name}`);
+      }
+
     });
     return resources;
   }

--- a/src/builders/libraryBuilder.ts
+++ b/src/builders/libraryBuilder.ts
@@ -89,11 +89,9 @@ export class LibraryBuilder {
 
       logger.debug(`generating CQL definitions for profile ${structureDef.name}`);
 
-      //const resourceHandler: Handler | null = createHandler(structureDef, this.valueSets);
-
       //This is hardcoded for the resource types that we can handle now.
       //We should expand upon this or find a better error handling method soon.
-      if (structureDef.type == ('Condition' || 'Observation') ) {
+      if (structureDef.type == 'Condition' || structureDef.type == 'Observation') {
         const resourceHandlerClass : typeof Handler = handlerLookup[structureDef.type];
 
         const resourceHandler: Handler | null  = new resourceHandlerClass(structureDef, this.valueSets);

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -50,11 +50,11 @@ export class Handler {
     if (codeRestriction !== null) {
       retVal.codes.push(codeRestriction);
       retVal.definitions.push({
-          name: this.structureDef.name ?? '',
-          resourceType: resourceType!,
-          lookupName: codeRestriction.name,
-          dataRequirement: codeRestriction.dataRequirement
-        });
+        name: this.structureDef.name ?? '',
+        resourceType: resourceType!,
+        lookupName: codeRestriction.name,
+        dataRequirement: codeRestriction.dataRequirement
+      });
     }
 
     if (valueSetRestriction != null) {
@@ -100,6 +100,6 @@ export class Handler {
 }
 
 export const handlerLookup: { [key: string]: typeof Handler } = {
-  'Condition': Handler,
-  'Observation': Handler,
+  Condition: Handler,
+  Observation: Handler
 };

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -37,6 +37,7 @@ export abstract class Handler {
   structureDef: R4.IStructureDefinition;
   valueSets: ValueSetObject[];
 
+
   constructor(structureDef: R4.IStructureDefinition, valueSets: ValueSetObject[]) {
     this.structureDef = structureDef;
     this.valueSets = valueSets;
@@ -44,8 +45,8 @@ export abstract class Handler {
 
   abstract process(): CQLResource;
 
-  getCodeRestriction(resourceType: string): CQLCodeDefinition | null {
-    const query = `snapshot.element.where(id = '${resourceType}.code').patternCodeableConcept.coding`;
+  getCodeRestriction(resourceType: string, attribute = 'code'): CQLCodeDefinition | null {
+    const query = `snapshot.element.where(id = '${resourceType}.${attribute}').patternCodeableConcept.coding`;
     const code = fhirpath.evaluate(this.structureDef, query)[0];
 
     return code
@@ -58,8 +59,8 @@ export abstract class Handler {
       : null;
   }
 
-  getValueSetRestriction(resourceType: string): CQLDefinition | null {
-    const query = `snapshot.element.where(id = '${resourceType}.code').binding.valueSet`;
+  getValueSetRestriction(resourceType: string, attribute = 'code'): CQLDefinition | null {
+    const query = `snapshot.element.where(id = '${resourceType}.${attribute}').binding.valueSet`;
     const valueSet = fhirpath.evaluate(this.structureDef, query)[0];
 
     if (valueSet) {
@@ -143,3 +144,9 @@ export function createHandler(structureDef: R4.IStructureDefinition, valueSets: 
       return null;
   }
 }
+
+export const handlerLookup: { [key: string]: typeof Handler } = {
+  'Condition': ConditionHandler,
+  'Observation': ObservationHandler,
+};
+


### PR DESCRIPTION
Refactored resource handlers by creating a handlerLookup object with key value pairs that point from each resource to its corresponding handler.

Removed abstract handler class and instead created one common handler class.