### PR TITLE
Specimen resource handling

### DIFF
--- a/src/__tests__/builders/libraryBuilder.test.ts
+++ b/src/__tests__/builders/libraryBuilder.test.ts
@@ -24,7 +24,10 @@ define "ExampleCondition":
 
 define "ExampleProcedure":
     [Procedure: "Example ValueSet"]
-`;
+
+define "ExampleSpecimen":
+    [Specimen: "Example ValueSet"]
+    `;
 
 const libraryBuilder = new LibraryBuilder(MOCK_IG_DIR, <R4.IImplementationGuide>implementationGuide);
 const { cql, resource, questionnaire } = libraryBuilder.buildLibrary();

--- a/src/__tests__/helpers/resourceHandlers.test.ts
+++ b/src/__tests__/helpers/resourceHandlers.test.ts
@@ -3,6 +3,7 @@ import { handlerLookup } from '../../helpers/resourceHandlers';
 import exampleObservation from '../mock-ig/site/StructureDefinition-example-observation.json';
 import exampleCondition from '../mock-ig/site/StructureDefinition-example-condition.json';
 import exampleProcedure from '../mock-ig/site/StructureDefinition-example-procedure.json';
+import exampleSpecimen from '../mock-ig/site/StructureDefinition-example-specimen.json';
 import { CQLResource } from '../../types/library-types';
 
 const MOCK_VALUESET_MAP = [
@@ -97,6 +98,26 @@ const EXPECTED_PROCEDURE_DEFINITIONS: CQLResource = {
   codes: []
 };
 
+const EXPECTED_SPECIMEN_DEFINITIONS: CQLResource = {
+  definitions: [
+    {
+      name: 'ExampleSpecimen',
+      resourceType: 'Specimen',
+      lookupName: 'Example ValueSet',
+      dataRequirement: {
+        type: 'Specimen',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'example-valueset'
+          }
+        ]
+      }
+    }
+  ],
+  codes: []
+};
+
 test('test handler for Observation', () => {
   const resourceHandlerClass = handlerLookup['Observation'];
   const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleObservation, MOCK_VALUESET_MAP);
@@ -124,4 +145,14 @@ test('test handler for Procedure', () => {
 
   const result = handler!.process();
   expect(result).toEqual(EXPECTED_PROCEDURE_DEFINITIONS);
+});
+
+test('test handler for Specimen', () => {
+  const resourceHandlerClass = handlerLookup['Specimen'];
+  const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleSpecimen, MOCK_VALUESET_MAP);
+
+  expect(handler).toBeDefined();
+
+  const result = handler!.process();
+  expect(result).toEqual(EXPECTED_SPECIMEN_DEFINITIONS);
 });

--- a/src/__tests__/mock-ig/questionnaire.json
+++ b/src/__tests__/mock-ig/questionnaire.json
@@ -48,6 +48,19 @@
         }
       ],
       "type": "string"
+    },
+    {
+      "linkId": "ExampleSpecimen",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "valueExpression": {
+            "language": "text/cql",
+            "expression": "\"example\".ExampleSpecimen"
+          }
+        }
+      ],
+      "type": "string"
     }
   ]
 }

--- a/src/__tests__/mock-ig/site/ImplementationGuide.json
+++ b/src/__tests__/mock-ig/site/ImplementationGuide.json
@@ -56,6 +56,20 @@
         "extension": [
           {
             "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:resource"
+          }
+        ],
+        "reference": {
+          "reference": "StructureDefinition/example-specimen"
+        },
+        "name": "ExampleSpecimen",
+        "description": "An Example Specimen",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
             "valueString": "ValueSet"
           }
         ],

--- a/src/__tests__/mock-ig/site/StructureDefinition-example-specimen.json
+++ b/src/__tests__/mock-ig/site/StructureDefinition-example-specimen.json
@@ -1,0 +1,43 @@
+{
+    "resourceType": "StructureDefinition",
+    "id": "example-specimen",
+    "url": "http://example.com/StructureDefinition/example-specimen",
+    "version": "0.0.1",
+    "name": "ExampleSpecimen",
+    "title": "ExampleSpecimen",
+    "status": "draft",
+    "fhirVersion": "4.0.0",
+    "kind": "resource",
+    "abstract": false,
+    "type": "Specimen",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Specimen",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "Specimen.type",
+          "path": "Specimen.type",
+          "short": "Kind of material that forms the specimen",
+          "definition": "The kind of material that forms the specimen.",
+          "comment": "The type can change the way that a specimen is handled and drives what kind of analyses can properly be performed on the specimen. It is frequently used in diagnostic work flow decision making systems.",
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "Specimen.type",
+            "min": 0,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "binding": {
+            "strength": "required",
+            "valueSet": "http://example.com/ValueSet/example-valueset"
+          }
+        }
+      ]
+    }
+  }
+  

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -104,7 +104,7 @@ export class SpecimenHandler extends Handler {
     const retVal: CQLResource = { definitions: [], codes: [] };
     const resourceType = this.structureDef.type;
     const codeRestriction = this.getCodeRestriction(resourceType!);
-    const valueSetRestriction = this.getValueSetRestriction(resourceType!,'type');
+    const valueSetRestriction = this.getValueSetRestriction(resourceType!, 'type');
 
     if (codeRestriction !== null) {
       retVal.codes.push(codeRestriction);

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -99,8 +99,34 @@ export class Handler {
   }
 }
 
+export class SpecimenHandler extends Handler {
+  process(): CQLResource {
+    const retVal: CQLResource = { definitions: [], codes: [] };
+    const resourceType = this.structureDef.type;
+    const codeRestriction = this.getCodeRestriction(resourceType!);
+    const valueSetRestriction = this.getValueSetRestriction(resourceType!,'type');
+
+    if (codeRestriction !== null) {
+      retVal.codes.push(codeRestriction);
+      retVal.definitions.push({
+        name: this.structureDef.name ?? '',
+        resourceType: resourceType!,
+        lookupName: codeRestriction.name,
+        dataRequirement: codeRestriction.dataRequirement
+      });
+    }
+
+    if (valueSetRestriction != null) {
+      retVal.definitions.push(valueSetRestriction);
+    }
+
+    return retVal;
+  }
+}
+
 export const handlerLookup: { [key: string]: typeof Handler } = {
   Condition: Handler,
   Observation: Handler,
-  Procedure: Handler
+  Procedure: Handler,
+  Specimen: SpecimenHandler
 };


### PR DESCRIPTION
- Created a SpecimenHandler class that overrides Handler.
- Added Specimen resource type as a key within handlerLookup object
- Created an example structure definition for specimen and added a test to `resourceHandlers.test.ts`
- Updated `libraryBuilders.test.ts` as well as supporting questionnaire and implementation guide files