### PR TITLE
Diagnostic report resource handling

### DIFF
--- a/src/__tests__/builders/libraryBuilder.test.ts
+++ b/src/__tests__/builders/libraryBuilder.test.ts
@@ -16,6 +16,8 @@ valueset "Example ValueSet": 'example-valueset'
 
 code "ExampleObservation Code": '88040-1' from "LOINC"
 
+code "ExampleDiagnosticReport Code": '81247-9' from "LOINC"
+
 define "ExampleObservation":
     [Observation: "ExampleObservation Code"]
 
@@ -27,6 +29,9 @@ define "ExampleProcedure":
 
 define "ExampleSpecimen":
     [Specimen: "Example ValueSet"]
+
+define "ExampleDiagnosticReport":
+    [DiagnosticReport: "ExampleDiagnosticReport Code"]
     `;
 
 const libraryBuilder = new LibraryBuilder(MOCK_IG_DIR, <R4.IImplementationGuide>implementationGuide);

--- a/src/__tests__/helpers/resourceHandlers.test.ts
+++ b/src/__tests__/helpers/resourceHandlers.test.ts
@@ -4,6 +4,7 @@ import exampleObservation from '../mock-ig/site/StructureDefinition-example-obse
 import exampleCondition from '../mock-ig/site/StructureDefinition-example-condition.json';
 import exampleProcedure from '../mock-ig/site/StructureDefinition-example-procedure.json';
 import exampleSpecimen from '../mock-ig/site/StructureDefinition-example-specimen.json';
+import exampleDiagnosticReport from '../mock-ig/site/StructureDefinition-example-diagnosticreport.json';
 import { CQLResource } from '../../types/library-types';
 
 const MOCK_VALUESET_MAP = [
@@ -118,6 +119,51 @@ const EXPECTED_SPECIMEN_DEFINITIONS: CQLResource = {
   codes: []
 };
 
+const EXPECTED_DIAGNOSTICREPORT_DEFINITIONS: CQLResource = {
+  definitions: [
+    {
+      name: 'ExampleDiagnosticReport',
+      resourceType: 'DiagnosticReport',
+      lookupName: 'ExampleDiagnosticReport Code',
+      dataRequirement: {
+        type: 'DiagnosticReport',
+        codeFilter: [
+          {
+            path: 'code',
+            code: [
+              {
+                code: '81247-9',
+                system: 'http://loinc.org'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  codes: [
+    {
+      name: 'ExampleDiagnosticReport Code',
+      code: '81247-9',
+      system: 'http://loinc.org',
+      dataRequirement: {
+        type: 'DiagnosticReport',
+        codeFilter: [
+          {
+            path: 'code',
+            code: [
+              {
+                code: '81247-9',
+                system: 'http://loinc.org'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+};
+
 test('test handler for Observation', () => {
   const resourceHandlerClass = handlerLookup['Observation'];
   const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleObservation, MOCK_VALUESET_MAP);
@@ -155,4 +201,14 @@ test('test handler for Specimen', () => {
 
   const result = handler!.process();
   expect(result).toEqual(EXPECTED_SPECIMEN_DEFINITIONS);
+});
+
+test('test handler for DiagnosticReport', () => {
+  const resourceHandlerClass = handlerLookup['DiagnosticReport'];
+  const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleDiagnosticReport, MOCK_VALUESET_MAP);
+
+  expect(handler).toBeDefined();
+
+  const result = handler!.process();
+  expect(result).toEqual(EXPECTED_DIAGNOSTICREPORT_DEFINITIONS);
 });

--- a/src/__tests__/mock-ig/questionnaire.json
+++ b/src/__tests__/mock-ig/questionnaire.json
@@ -61,6 +61,19 @@
         }
       ],
       "type": "string"
+    },
+    {
+      "linkId": "ExampleDiagnosticReport",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "valueExpression": {
+            "language": "text/cql",
+            "expression": "\"example\".ExampleDiagnosticReport"
+          }
+        }
+      ],
+      "type": "string"
     }
   ]
 }

--- a/src/__tests__/mock-ig/site/ImplementationGuide.json
+++ b/src/__tests__/mock-ig/site/ImplementationGuide.json
@@ -70,6 +70,20 @@
         "extension": [
           {
             "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:resource"
+          }
+        ],
+        "reference": {
+          "reference": "StructureDefinition/example-diagnosticreport"
+        },
+        "name": "ExampleDiagnosticReport",
+        "description": "An Example DiagnosticReport",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
             "valueString": "ValueSet"
           }
         ],

--- a/src/__tests__/mock-ig/site/StructureDefinition-example-diagnosticreport.json
+++ b/src/__tests__/mock-ig/site/StructureDefinition-example-diagnosticreport.json
@@ -1,0 +1,60 @@
+{
+    "resourceType": "StructureDefinition",
+    "id": "example-diagnosticreport",
+    "url": "http://example.com/StructureDefinition/example-diagnosticreport",
+    "version": "0.0.1",
+    "name": "ExampleDiagnosticReport",
+    "title": "ExampleDiagnosticReport",
+    "status": "draft",
+    "fhirVersion": "4.0.0",
+    "kind": "resource",
+    "abstract": false,
+    "type": "DiagnosticReport",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/us-core-diagnosticreport-lab",
+    "derivation": "constraint",
+    "snapshot": {
+      "element": [
+        {
+          "id": "DiagnosticReport.code",
+          "path": "DiagnosticReport.code",
+          "short": "US Core Laboratory Report Order Code",
+          "definition": "The test, panel or battery that was ordered.",
+          "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+          "requirements": "0..1 to account for primarily narrative only resources.",
+          "alias": ["type"],
+          "min": 1,
+          "max": "1",
+          "base": {
+            "path": "DiagnosticReport.code",
+            "min": 1,
+            "max": "1"
+          },
+          "type": [
+            {
+              "code": "CodeableConcept"
+            }
+          ],
+          "patternCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "81247-9"
+              }
+            ]
+          },
+          "binding": {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                "valueString": "ObservationCode"
+              }
+            ],
+            "strength": "extensible",
+            "description": "LOINC codes",
+            "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes"
+          }
+        }
+      ]
+    }
+  }
+  

--- a/src/__tests__/mock-ig/site/StructureDefinition-example-diagnosticreport.json
+++ b/src/__tests__/mock-ig/site/StructureDefinition-example-diagnosticreport.json
@@ -46,7 +46,7 @@
             "extension": [
               {
                 "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-                "valueString": "ObservationCode"
+                "valueString": "DiagnosticReportCodes"
               }
             ],
             "strength": "extensible",

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -128,5 +128,6 @@ export const handlerLookup: { [key: string]: typeof Handler } = {
   Condition: Handler,
   Observation: Handler,
   Procedure: Handler,
+  DiagnosticReport: Handler,
   Specimen: SpecimenHandler
 };


### PR DESCRIPTION
- Added handling for diagnostic report resource type
- Added a resourceHandler test for diagnostic report
- Added testing functionality for diagnostic report to the libraryBuilder test

Note: I created the tests for diagnostic report similarly to how the Observation tests are set up.