### PR TITLE
Medication statement resource handler

### DIFF
--- a/src/__tests__/builders/libraryBuilder.test.ts
+++ b/src/__tests__/builders/libraryBuilder.test.ts
@@ -32,6 +32,9 @@ define "ExampleSpecimen":
 
 define "ExampleDiagnosticReport":
     [DiagnosticReport: "ExampleDiagnosticReport Code"]
+
+define "ExampleMedicationStatement":
+    [MedicationStatement: "Example ValueSet"]
     `;
 
 const libraryBuilder = new LibraryBuilder(MOCK_IG_DIR, <R4.IImplementationGuide>implementationGuide);

--- a/src/__tests__/helpers/resourceHandlers.test.ts
+++ b/src/__tests__/helpers/resourceHandlers.test.ts
@@ -5,6 +5,7 @@ import exampleCondition from '../mock-ig/site/StructureDefinition-example-condit
 import exampleProcedure from '../mock-ig/site/StructureDefinition-example-procedure.json';
 import exampleSpecimen from '../mock-ig/site/StructureDefinition-example-specimen.json';
 import exampleDiagnosticReport from '../mock-ig/site/StructureDefinition-example-diagnosticreport.json';
+import exampleMedicationStatement from '../mock-ig/site/StructureDefinition-example-medicationstatement.json';
 import { CQLResource } from '../../types/library-types';
 
 const MOCK_VALUESET_MAP = [
@@ -164,6 +165,26 @@ const EXPECTED_DIAGNOSTICREPORT_DEFINITIONS: CQLResource = {
   ]
 };
 
+const EXPECTED_MEDICATIONSTATEMENT_DEFINITIONS: CQLResource = {
+  definitions: [
+    {
+      name: 'ExampleMedicationStatement',
+      resourceType: 'MedicationStatement',
+      lookupName: 'Example ValueSet',
+      dataRequirement: {
+        type: 'MedicationStatement',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'example-valueset'
+          }
+        ]
+      }
+    }
+  ],
+  codes: []
+};
+
 test('test handler for Observation', () => {
   const resourceHandlerClass = handlerLookup['Observation'];
   const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleObservation, MOCK_VALUESET_MAP);
@@ -211,4 +232,14 @@ test('test handler for DiagnosticReport', () => {
 
   const result = handler!.process();
   expect(result).toEqual(EXPECTED_DIAGNOSTICREPORT_DEFINITIONS);
+});
+
+test('test handler for MedicationStatement', () => {
+  const resourceHandlerClass = handlerLookup['MedicationStatement'];
+  const handler = new resourceHandlerClass(<R4.IStructureDefinition>exampleMedicationStatement, MOCK_VALUESET_MAP);
+
+  expect(handler).toBeDefined();
+
+  const result = handler!.process();
+  expect(result).toEqual(EXPECTED_MEDICATIONSTATEMENT_DEFINITIONS);
 });

--- a/src/__tests__/mock-ig/questionnaire.json
+++ b/src/__tests__/mock-ig/questionnaire.json
@@ -74,6 +74,19 @@
         }
       ],
       "type": "string"
+    },
+    {
+      "linkId": "ExampleMedicationStatement",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "valueExpression": {
+            "language": "text/cql",
+            "expression": "\"example\".ExampleMedicationStatement"
+          }
+        }
+      ],
+      "type": "string"
     }
   ]
 }

--- a/src/__tests__/mock-ig/site/ImplementationGuide.json
+++ b/src/__tests__/mock-ig/site/ImplementationGuide.json
@@ -84,6 +84,20 @@
         "extension": [
           {
             "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+            "valueString": "StructureDefinition:resource"
+          }
+        ],
+        "reference": {
+          "reference": "StructureDefinition/example-medicationstatement"
+        },
+        "name": "ExampleMedicationStatement",
+        "description": "An Example MedicationStatement",
+        "exampleBoolean": false
+      },
+      {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
             "valueString": "ValueSet"
           }
         ],

--- a/src/__tests__/mock-ig/site/StructureDefinition-example-medicationstatement.json
+++ b/src/__tests__/mock-ig/site/StructureDefinition-example-medicationstatement.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "example-medicationstatement",
+  "url": "http://example.com/StructureDefinition/example-medicationstatement",
+  "version": "0.0.1",
+  "name": "ExampleMedicationStatement",
+  "title": "ExampleMedicationStatement",
+  "status": "draft",
+  "fhirVersion": "4.0.0",
+  "kind": "resource",
+  "abstract": false,
+  "type": "MedicationStatement",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+  "derivation": "constraint",
+  "snapshot": {
+    "element": [
+      {
+        "id": "MedicationStatement.medication[x]:medicationCodeableConcept",
+        "path": "MedicationStatement.medication[x]",
+        "short": "What medication was taken",
+        "definition": "Identifies the medication being administered. This is either a link to a resource representing the details of the medication or a simple attribute carrying a code that identifies the medication from a known list of medications.",
+        "comment": "If only a code is specified, then it needs to be a code for a specific product. If more information is required, then the use of the medication resource is recommended.  For example, if you require form or lot number, then you must reference the Medication resource.",
+        "min": 0,
+        "max": "1",
+        "base": {
+          "path": "MedicationStatement.medication[x]",
+          "min": 1,
+          "max": "1"
+        },
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ],
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://example.com/ValueSet/example-valueset"
+        }
+      }
+    ]
+  }
+}

--- a/src/helpers/resourceHandlers.ts
+++ b/src/helpers/resourceHandlers.ts
@@ -124,10 +124,36 @@ export class SpecimenHandler extends Handler {
   }
 }
 
+export class MedicationStatementHandler extends Handler {
+  process(): CQLResource {
+    const retVal: CQLResource = { definitions: [], codes: [] };
+    const resourceType = this.structureDef.type;
+    const codeRestriction = this.getCodeRestriction(resourceType!);
+    const valueSetRestriction = this.getValueSetRestriction(resourceType!, 'medication[x]:medicationCodeableConcept');
+
+    if (codeRestriction !== null) {
+      retVal.codes.push(codeRestriction);
+      retVal.definitions.push({
+        name: this.structureDef.name ?? '',
+        resourceType: resourceType!,
+        lookupName: codeRestriction.name,
+        dataRequirement: codeRestriction.dataRequirement
+      });
+    }
+
+    if (valueSetRestriction != null) {
+      retVal.definitions.push(valueSetRestriction);
+    }
+
+    return retVal;
+  }
+}
+
 export const handlerLookup: { [key: string]: typeof Handler } = {
   Condition: Handler,
   Observation: Handler,
   Procedure: Handler,
   DiagnosticReport: Handler,
-  Specimen: SpecimenHandler
+  Specimen: SpecimenHandler,
+  MedicationStatement: MedicationStatementHandler
 };


### PR DESCRIPTION
Added resource handling and testing for MedicationStatements.

Required an extension to the base handler class since the attribute we want to look for is `medication[x]:medicationCodeableConcept`

Note: `medication[x]` has a choice of data types - it can either be just `medication[x]` or `medication[x]:medicationCodeableConcept`. I chose to implement it by looking for the `medication[x]:medicationCodeableConcept` attribute, since the mCODE defined binding for this within the CancerRelatedMedicationStatement StructureDefinition is the value set of US Core RxNorm codes, whereas the value set for the other one is a bunch of SNOMED medication codes.