### PR TITLE
Sdc Questionnaire Building

### DIFF
--- a/src/__tests__/mock-ig/questionnaire.json
+++ b/src/__tests__/mock-ig/questionnaire.json
@@ -14,7 +14,7 @@
       "linkId": "ExampleObservation",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleObservation"
@@ -27,7 +27,7 @@
       "linkId": "ExampleCondition",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleCondition"
@@ -40,7 +40,7 @@
       "linkId": "ExampleProcedure",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleProcedure"
@@ -53,7 +53,7 @@
       "linkId": "ExampleSpecimen",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleSpecimen"
@@ -66,7 +66,7 @@
       "linkId": "ExampleDiagnosticReport",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleDiagnosticReport"
@@ -79,7 +79,7 @@
       "linkId": "ExampleMedicationStatement",
       "extension": [
         {
-          "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
           "valueExpression": {
             "language": "text/cql",
             "expression": "\"example\".ExampleMedicationStatement"
@@ -90,3 +90,4 @@
     }
   ]
 }
+

--- a/src/builders/questionnaireBuilder.ts
+++ b/src/builders/questionnaireBuilder.ts
@@ -26,7 +26,7 @@ export class QuestionnaireBuilder {
       linkId: expression,
       extension: [
         {
-          url: 'http://hl7.org/fhir/StructureDefinition/cqf-expression',
+          url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression',
           valueExpression: {
             language: R4.ExpressionLanguageKind._textCql,
             expression: `"${this.libraryName}".${expression}`


### PR DESCRIPTION
It looks like the candidate Expression extension does make the most sense for what we want to do. 

According to the [Structure Definition](http://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-candidateExpression.html), it follows the same format as we were currently using for cqf-expression, except with a different URL.

The FHIR Library reference in the questionnaire should actually stay the same, according to the [SDC IG](http://build.fhir.org/ig/HL7/sdc/expressions.html#other-extensions).


For this PR, I replaced the URL in the questionnaireBuilder and then updated the exampleQuestionnaire URLs for testing purposes.