### PR TITLE
Add text to questionnaire builder

### DIFF
--- a/src/__tests__/helpers/bundler.test.ts
+++ b/src/__tests__/helpers/bundler.test.ts
@@ -7,5 +7,5 @@ test('function returns a valid collection bundle containing the resource', () =>
   const bundle = bundlify(resourceList);
 
   expect(bundle.resourceType).toBe('Bundle');
-  expect(bundle.entry).toContainEqual({ resource: implementationGuide });
+  expect(bundle.entry).toContainEqual([{fullUrl: 'urn:uuid:example', resource: implementationGuide }]);
 });

--- a/src/__tests__/helpers/bundler.test.ts
+++ b/src/__tests__/helpers/bundler.test.ts
@@ -7,8 +7,6 @@ test('function returns a valid collection bundle containing the resource', () =>
   const bundle = bundlify(resourceList);
 
   expect(bundle.resourceType).toBe('Bundle');
-  console.log(typeof(bundle.resourceType));
-  console.log(typeof([{fullUrl: 'urn:uuid:example', resource: implementationGuide }]));
   
-  expect(bundle.entry).toContainEqual([{fullUrl: 'urn:uuid:example', resource: implementationGuide }]);
+  expect(bundle.entry).toContainEqual([{fullUrl: 'urn:uuid:example', resource: implementationGuide }][0]);
 });

--- a/src/__tests__/helpers/bundler.test.ts
+++ b/src/__tests__/helpers/bundler.test.ts
@@ -7,5 +7,5 @@ test('function returns a valid collection bundle containing the resource', () =>
   const bundle = bundlify(resourceList);
 
   expect(bundle.resourceType).toBe('Bundle');
-  expect(bundle.entry).toContainEqual([{ fullUrl: 'urn:uuid:example', resource: implementationGuide }][0]);
+  expect(bundle.entry).toContainEqual({ fullUrl: 'urn:uuid:example', resource: implementationGuide });
 });

--- a/src/__tests__/helpers/bundler.test.ts
+++ b/src/__tests__/helpers/bundler.test.ts
@@ -7,6 +7,5 @@ test('function returns a valid collection bundle containing the resource', () =>
   const bundle = bundlify(resourceList);
 
   expect(bundle.resourceType).toBe('Bundle');
-  
-  expect(bundle.entry).toContainEqual([{fullUrl: 'urn:uuid:example', resource: implementationGuide }][0]);
+  expect(bundle.entry).toContainEqual([{ fullUrl: 'urn:uuid:example', resource: implementationGuide }][0]);
 });

--- a/src/__tests__/helpers/bundler.test.ts
+++ b/src/__tests__/helpers/bundler.test.ts
@@ -7,5 +7,8 @@ test('function returns a valid collection bundle containing the resource', () =>
   const bundle = bundlify(resourceList);
 
   expect(bundle.resourceType).toBe('Bundle');
+  console.log(typeof(bundle.resourceType));
+  console.log(typeof([{fullUrl: 'urn:uuid:example', resource: implementationGuide }]));
+  
   expect(bundle.entry).toContainEqual([{fullUrl: 'urn:uuid:example', resource: implementationGuide }]);
 });

--- a/src/__tests__/helpers/resourceHandlers.test.ts
+++ b/src/__tests__/helpers/resourceHandlers.test.ts
@@ -71,7 +71,7 @@ const EXPECTED_CONDITION_DEFINITIONS: CQLResource = {
         codeFilter: [
           {
             path: 'code',
-            valueSet: 'example-valueset'
+            valueSet: 'urn:uuid:example-valueset'
           }
         ]
       }
@@ -91,7 +91,7 @@ const EXPECTED_PROCEDURE_DEFINITIONS: CQLResource = {
         codeFilter: [
           {
             path: 'code',
-            valueSet: 'example-valueset'
+            valueSet: 'urn:uuid:example-valueset'
           }
         ]
       }
@@ -111,7 +111,7 @@ const EXPECTED_SPECIMEN_DEFINITIONS: CQLResource = {
         codeFilter: [
           {
             path: 'code',
-            valueSet: 'example-valueset'
+            valueSet: 'urn:uuid:example-valueset'
           }
         ]
       }
@@ -176,7 +176,7 @@ const EXPECTED_MEDICATIONSTATEMENT_DEFINITIONS: CQLResource = {
         codeFilter: [
           {
             path: 'code',
-            valueSet: 'example-valueset'
+            valueSet: 'urn:uuid:example-valueset'
           }
         ]
       }

--- a/src/__tests__/mock-ig/questionnaire.json
+++ b/src/__tests__/mock-ig/questionnaire.json
@@ -12,6 +12,7 @@
   "item": [
     {
       "linkId": "ExampleObservation",
+      "text": "ExampleObservation",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
@@ -25,6 +26,7 @@
     },
     {
       "linkId": "ExampleCondition",
+      "text": "ExampleCondition",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
@@ -38,6 +40,7 @@
     },
     {
       "linkId": "ExampleProcedure",
+      "text": "ExampleProcedure",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
@@ -51,6 +54,7 @@
     },
     {
       "linkId": "ExampleSpecimen",
+      "text": "ExampleSpecimen",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
@@ -64,6 +68,7 @@
     },
     {
       "linkId": "ExampleDiagnosticReport",
+      "text": "ExampleDiagnosticReport",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",
@@ -77,6 +82,7 @@
     },
     {
       "linkId": "ExampleMedicationStatement",
+      "text": "ExampleMedicationStatement",
       "extension": [
         {
           "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression",

--- a/src/builders/questionnaireBuilder.ts
+++ b/src/builders/questionnaireBuilder.ts
@@ -24,6 +24,7 @@ export class QuestionnaireBuilder {
   addCqfExpression(expression: string): void {
     this.questionnaire.item!.push({
       linkId: expression,
+      text: expression,
       extension: [
         {
           url: 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression',


### PR DESCRIPTION
Questionnaire Builder Changes:
- Added `text` field to questionnaire Builder.
- Updated `src/__tests__/mock-ig/questionnaire.json` to account for changes so that `libraryBuilder.test` passes

Other changes (since other test suites were failing):
- Updated `resourceHandlers.test.ts` test to account for changes to `bundler.ts`
- ~Still need to fix `bundler.test.ts` -> I think there is an issue with the test expecting a different type.~
- Updated `bundler.test.ts` to properly check equality of bundles



To Test: 
- Outputted questionnaire items should all have `text` field.
- All tests pass (~right now just `bundler.test.ts` should fail~).
